### PR TITLE
n2log-unscramble: implement --inversed-match

### DIFF
--- a/bin/n2log-unscramble
+++ b/bin/n2log-unscramble
@@ -51,10 +51,7 @@ def unscramble(file, output, *, level='INFO', predicate=lambda s: True):
             if not is_level_enabled(msg.get('level'), level):
                 continue
 
-            for value in msg.values():
-                if predicate(str(value)):
-                    break
-            else:
+            if not predicate(msg.values()):
                 continue
 
             print(
@@ -81,9 +78,9 @@ def unscramble(file, output, *, level='INFO', predicate=lambda s: True):
 def generate_predicate(search_term, flags):
     if search_term is not None:
         regex = re.compile(search_term, reduce(operator.or_, flags))
-        return lambda s: regex.search(s)
+        return lambda s: regex.search(str(s))
     else:
-        return lambda s: True
+        return None
 
 
 def main():
@@ -93,6 +90,7 @@ def main():
                                         'trace or an MDC field (session_id, user_name, …).')
     arg_parser.add_argument('--ignore-case', '-i', dest='regex_flags', default=[re.MULTILINE],
                             action='append_const', const=re.IGNORECASE, help='Ignore case in SEARCH_TERM.')
+    arg_parser.add_argument('--inverted-match', '-v', help='Search terms to be excluded in result.')
     arg_parser.add_argument('--file', '-f', type=open, default=sys.stdin, nargs='?',
                        help='File from which to read logs. If omitted, logs are read from stdin')
     arg_parser.add_argument('--level', '-l', default='trace', choices=['trace', 'info', 'warn', 'error'],
@@ -100,10 +98,20 @@ def main():
     args = arg_parser.parse_args()
 
     try:
-        predicate = generate_predicate(args.search_term, args.regex_flags)
+        predicate_positive = generate_predicate(args.search_term, args.regex_flags)
+        predicate_negative = generate_predicate(args.inverted_match, args.regex_flags)
     except re.error as e:
-        message = 'failed to compile regular expression {!r}: {}'.format(args.search_term, e)
+        message = 'failed to compile regular expression {!r}: {}'.format(e.pattern, e)
         arg_parser.error(argparse.ArgumentError(term, message))
+
+    def predicate(values):
+        if predicate_negative is not None and any(map(predicate_negative, values)):
+            return False
+
+        if predicate_positive is not None:
+            return any(map(predicate_positive, values))
+
+        return True
 
     unscramble(args.file, sys.stdout, level=args.level, predicate=predicate)
 

--- a/bin/n2log-unscramble
+++ b/bin/n2log-unscramble
@@ -1,6 +1,7 @@
 #!/usr/bin/python3
 import argparse
 from datetime import datetime, timezone
+import enum
 from functools import reduce
 import json
 import operator
@@ -8,13 +9,21 @@ import re
 import sys
 
 NON_MDC = {'message', 'level', 'logger_name', 'message', 'thread_name', 'version', 'revision', 'tags', 'level_name', '@timestamp', 'stack_trace'}
-LEVELS = {
-    'trace': 0,
-    'debug': 1,
-    'info': 2,
-    'warn': 3,
-    'error': 4
-}
+
+
+class NotALogMessageError(Exception):
+    pass
+
+
+class Level(enum.IntEnum):
+    TRACE = 0,
+    DEBUG = 1,
+    INFO = 2,
+    WARN = 3,
+    ERROR = 4
+
+LEVEL_MIN = min(Level)
+LEVEL_MAX = max(Level)
 
 
 def local_time(ts):
@@ -40,13 +49,16 @@ def is_level_enabled(level, level_enabled):
     if level is None:
         return True
 
-    return LEVELS[level_enabled] <= LEVELS[level.lower()]
+    return level_enabled <= getattr(Level, level.upper(), LEVEL_MAX)
 
 
 def unscramble(file, output, *, level='INFO', predicate=lambda s: True):
     for line in file:
         try:
             msg = json.loads(line)
+
+            if not isinstance(msg, dict):
+                raise NotALogMessageError()
 
             if not is_level_enabled(msg.get('level'), level):
                 continue
@@ -70,7 +82,7 @@ def unscramble(file, output, *, level='INFO', predicate=lambda s: True):
                 print()
                 print(trace)
             print('=' * 100)
-        except json.decoder.JSONDecodeError:
+        except (json.decoder.JSONDecodeError, NotALogMessageError):
             if predicate(line):
                 print('PLAIN TEXT: ', line, end='', file=output)
 
@@ -84,6 +96,10 @@ def generate_predicate(search_term, flags):
 
 
 def main():
+    class LevelAction(argparse.Action):
+        def __call__(self, parser, namespace, value, option_string=None):
+            setattr(namespace, self.dest, getattr(Level, value.upper()))
+
     arg_parser = argparse.ArgumentParser(description='unscramble Nice logfiles obtained using `oc logs …`')
     term = arg_parser.add_argument('search_term', metavar='SEARCH_TERM', nargs='?',
                                    help='Search pattern (regex) that need to appears in the log message stack '
@@ -93,8 +109,9 @@ def main():
     arg_parser.add_argument('--inverted-match', '-v', help='Search terms to be excluded in result.')
     arg_parser.add_argument('--file', '-f', type=open, default=sys.stdin, nargs='?',
                        help='File from which to read logs. If omitted, logs are read from stdin')
-    arg_parser.add_argument('--level', '-l', default='trace', choices=['trace', 'info', 'warn', 'error'],
-                            help='Max. log level shown')
+    arg_parser.add_argument('--level', '-l', default=LEVEL_MIN,
+                            choices=[i.name.lower() for i in Level],
+                            action=LevelAction, help='Max. log level shown')
     args = arg_parser.parse_args()
 
     try:

--- a/bin/n2log-unscramble
+++ b/bin/n2log-unscramble
@@ -83,7 +83,7 @@ def unscramble(file, output, *, level='INFO', predicate=lambda s: True):
                 print(trace)
             print('=' * 100)
         except (json.decoder.JSONDecodeError, NotALogMessageError):
-            if predicate(line):
+            if predicate([line]):
                 print('PLAIN TEXT: ', line, end='', file=output)
 
 


### PR DESCRIPTION
* Implement -i/--inversed-match
* Do not crash if line is valid JSON but not a dictionary
* Use IntEnum for log levels
* If log level can't be determined, consider message to be an error.