### PR TITLE
Set CheckHostIP to no

### DIFF
--- a/ssh/config
+++ b/ssh/config
@@ -29,6 +29,7 @@ Host *.tocco.ch
     StrictHostKeyChecking yes
     User tocco
     UserKnownHostsFile ~/.ssh/known_hosts_tocco
+    CheckHostIP no
 
 # uncomment in case git.tocco.ch is down
 #
@@ -42,6 +43,7 @@ Match host "*.tocco.ch,!git.tocco.ch,!backup02.tocco.ch,!backup2.tocco.ch" exec 
 Host *.tocco.cust.vshn.net
     StrictHostKeyChecking yes
     UserKnownHostsFile ~/.ssh/known_hosts_tocco
+    CheckHostIP no
 
 Host *
     # new in OpenSSH 7.2


### PR DESCRIPTION
This makes it harder to manage keys via Git as the known_hosts
file is modified. Also, it makes it harder to disable a host key
algorithm since ssh is going to complain if the server stops offering
a key it has in the known_hosts.